### PR TITLE
Made the missing particle error more specific

### DIFF
--- a/execute.py
+++ b/execute.py
@@ -73,7 +73,9 @@ def register_particle(addr):
     """This function inits the particle."""
     url = f"{node_url}/register_particle"
     response = requests.post(url, timeout=10, json={"address": addr})
-    if response.status_code != 200:
+    if response.status_code == 500:
+        raise Exception(f"No task available: Try later.")
+    elif response.status_code != 200:
         raise Exception(f"Failed to init particle: Try later.")
     task = response.json()
     return task['args']


### PR DESCRIPTION
It really bothered me that the error for when no job available was something that made me thing the miner was broken. 
So i added an exception for the Error 500 which is the one you guys are using for no job, and then it still defaults to the old error message for all the other responses other than 200 and 500